### PR TITLE
Command Palette Bug Fix

### DIFF
--- a/src/assets/base.css
+++ b/src/assets/base.css
@@ -38,7 +38,7 @@
 
   --color-border: var(--color-text);
 
-  --color-outline: var(--vt-c-text-dark-2);
+  --color-outline: lightgreen;
 
   --scroll-background: #eee;
   --scroll-foreground: #333333;

--- a/src/components/CommandPaletteComponent.vue
+++ b/src/components/CommandPaletteComponent.vue
@@ -87,7 +87,7 @@ onUpdated(() => {
     <div class="command-palette" v-show="$props.show">
         <div class="palette">
             <Input :autoFocus="true" ref="input" :value="searchTerm" @update:value="useThrottle($event, search, 500)"
-                placeholder="Search..." />
+                placeholder="Search..." @focus="focusSearch" />
             <div class="results" ref="resultsRef">
                 <router-link :to="result" @click="$emit('hide')" class="result"
                     v-for="result, index in Object.keys(results)" :key="index">
@@ -150,6 +150,11 @@ onUpdated(() => {
     border: 1px solid var(--color-border);
     margin: 5px 0;
     border-radius: 2.5px;
-    outline: 1px solid var(--color-outline);
+    outline: 1px solid transparent;
+}
+
+.command-palette .results .result:focus {
+    border-color: var(--color-outline);
+    outline-color: var(--color-outline);
 }
 </style>

--- a/src/components/InputComponent.vue
+++ b/src/components/InputComponent.vue
@@ -2,7 +2,7 @@
 import { useSnackbar } from '@/stores/snackbar';
 import { ref } from 'vue';
 const props = defineProps(['label', 'placeholder', 'inputType', 'value', 'disabled', 'allowCopy', 'error', 'helper']);
-defineEmits(['update:value']);
+defineEmits(['update:value', 'focus']);
 
 const snackbar = useSnackbar();
 const wrapper = ref();
@@ -22,7 +22,7 @@ defineExpose({
 <template>
     <ui-textfield outlined :input-type="inputType || 'text'" :class="'input ' + $attrs.class" :label="label"
         :placeholder="placeholder" :model-value="value" :disabled="disabled"
-        @update:model-value="$emit('update:value', $event)" ref="wrapper">
+        @update:model-value="$emit('update:value', $event)" ref="wrapper" @focus="$emit('focus')">
         <template #after v-if="Boolean(allowCopy)">
             <ui-textfield-icon @click="copyContent">content_copy</ui-textfield-icon>
         </template>

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -53,8 +53,7 @@ const starModule = (e: Event, moduleId: any) => {
 
 function handleKeyPress(e: KeyboardEvent) {
   const key = e.key || e.code || e.which || e.keyCode;
-
-  if ((key === 'P' || key === 'KeyP' || key == 80) && e.ctrlKey) {
+  if ((key === 'p' || key === 'P' || key === 'KeyP' || key == 80) && e.ctrlKey) {
     e.preventDefault()
     if (searchInput?.value?.wrapper?.wrapper?.textfield?.querySelector) {
       searchInput.value.wrapper!.wrapper!.textfield!.querySelector('input')!.focus()

--- a/src/views/ModuleView.vue
+++ b/src/views/ModuleView.vue
@@ -47,8 +47,7 @@ onUpdated(() => {
 
 function handleKeyPress(e: KeyboardEvent) {
     const key = e.key || e.code || e.which || e.keyCode;
-
-    if ((key === 'P' || key === 'KeyP' || key == 80) && e.ctrlKey) {
+    if ((key === 'p' || key === 'P' || key === 'KeyP' || key == 80) && e.ctrlKey) {
         e.preventDefault()
         showCommandPalette.value = true;
     }


### PR DESCRIPTION
## Changes

- Command Palette can now be opened using `Ctrl + p` or `Ctrl + Shift + p`,
- Fixed the bug where if you are focused on the Command Palette result and then change focus to search it doesn't reset the focus counter,
- Added highlight to the focused Command Palette result

Command Palette can now be opened using `Ctrl + p` or `Ctrl + Shift + p` change was made because in Firefox `Ctrl + Shift + p` opens private browsing window.

### Visual Changes

Before:
![image](https://github.com/pratyushtiwary/devty/assets/36852896/d0eb75a4-6290-4eeb-8734-6ada6151fad7)

After:
![image](https://github.com/pratyushtiwary/devty/assets/36852896/be087b14-67e7-4261-a70d-29d78391552d)
